### PR TITLE
chore: set the deploy job to run only on push

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build and test:
     runs-on: ubuntu-latest
+    env:
       TEST_USERNAME: postgres
       TEST_PASSWORD: password
       TEST_DB_NAME: db_name
@@ -48,7 +49,7 @@ jobs:
         run: curl http://localhost:8019
       - name: Run All Tests
         run: go test ./... -timeout 99999s
-  
+
   deploy:
     runs-on: ubuntu-latest
     needs: test

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -9,22 +9,8 @@ on:
       - dev
 
 jobs:
-  build:
+  build and test:
     runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-      - name: Set Golang
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.22.1"
-      - name: Build the application
-        run: go build -o development_app
-
-  test:
-    runs-on: ubuntu-latest
-    needs: build
-    env:
       TEST_USERNAME: postgres
       TEST_PASSWORD: password
       TEST_DB_NAME: db_name
@@ -46,14 +32,27 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+      - name: Set Golang
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.22.1"
       - name: Create app config file
         run: cp app-sample.env app.env
+      - name: Build the application
+        run: go build -o development_app
+      - name: Run the application
+        run: nohup ./development_app > /dev/null 2>&1 &
+      - name: Wait for application to start
+        run: sleep 30s
+      - name: Test for reachability
+        run: curl http://localhost:8019
       - name: Run All Tests
         run: go test ./... -timeout 99999s
-
+  
   deploy:
     runs-on: ubuntu-latest
     needs: test
+    if: github.event_name == 'push'
     env:
       SSH_USERNAME: ${{ secrets.SSH_USERNAME }}
       SSH_HOST: ${{ secrets.SSH_HOST }}
@@ -87,4 +86,4 @@ jobs:
               git clone -b dev https://github.com/${{ github.repository}} . || { echo "Failed to clone repository"; exit 1; }
             fi
 
-            bash ./scripts/deploy_app.sh development https://github.com/${{ github.repository}} SERVER_PORT=${{ env.SERVER_PORT }} DB_NAME=${{ env.DB_NAME }} USERNAME=${{ env.USERNAME }} APP_NAME=${{ env.APP_NAME }} APP_URL=${{ env.APP_URL }}
+            bash ./scripts/deploy_app.sh development https://github.com/${{ github.repository}} SERVER_PORT=${{ env.SERVER_PORT }} DB_NAME=${{ env.DB_NAME }} USERNAME=${{ env.USERNAME }} APP_NAME=${{ env.APP_NAME }} APP_URL=${{ env.APP_URL }} MIGTRATE=true

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -52,7 +52,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    needs: test
+    needs: build_and_test
     if: github.event_name == 'push'
     env:
       SSH_USERNAME: ${{ secrets.SSH_USERNAME }}

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -9,7 +9,7 @@ on:
       - dev
 
 jobs:
-  build and test:
+  build_and_test:
     runs-on: ubuntu-latest
     env:
       TEST_USERNAME: postgres

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -86,4 +86,4 @@ jobs:
               git clone -b dev https://github.com/${{ github.repository}} . || { echo "Failed to clone repository"; exit 1; }
             fi
 
-            bash ./scripts/deploy_app.sh development https://github.com/${{ github.repository}} SERVER_PORT=${{ env.SERVER_PORT }} DB_NAME=${{ env.DB_NAME }} USERNAME=${{ env.USERNAME }} APP_NAME=${{ env.APP_NAME }} APP_URL=${{ env.APP_URL }} MIGTRATE=true
+            bash ./scripts/deploy_app.sh development https://github.com/${{ github.repository}} SERVER_PORT=${{ env.SERVER_PORT }} DB_NAME=${{ env.DB_NAME }} USERNAME=${{ env.USERNAME }} APP_NAME=${{ env.APP_NAME }} APP_URL=${{ env.APP_URL }} MIGRATE=true

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build and test:
     runs-on: ubuntu-latest
+    env:
       TEST_USERNAME: postgres
       TEST_PASSWORD: password
       TEST_DB_NAME: db_name
@@ -48,7 +49,7 @@ jobs:
         run: curl http://localhost:8019
       - name: Run All Tests
         run: go test ./... -timeout 99999s
-  
+
   deploy:
     runs-on: ubuntu-latest
     needs: test

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  build and test:
+  build_and_test:
     runs-on: ubuntu-latest
     env:
       TEST_USERNAME: postgres

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -9,22 +9,8 @@ on:
       - main
 
 jobs:
-  build:
+  build and test:
     runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-      - name: Set Golang
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.22.1"
-      - name: Build the application
-        run: go build -o production_app
-
-  test:
-    runs-on: ubuntu-latest
-    needs: build
-    env:
       TEST_USERNAME: postgres
       TEST_PASSWORD: password
       TEST_DB_NAME: db_name
@@ -46,14 +32,27 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+      - name: Set Golang
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.22.1"
       - name: Create app config file
         run: cp app-sample.env app.env
+      - name: Build the application
+        run: go build -o production_app
+      - name: Run the application
+        run: nohup ./production_app > /dev/null 2>&1 &
+      - name: Wait for application to start
+        run: sleep 30s
+      - name: Test for reachability
+        run: curl http://localhost:8019
       - name: Run All Tests
         run: go test ./... -timeout 99999s
-
+  
   deploy:
     runs-on: ubuntu-latest
     needs: test
+    if: github.event_name == 'push'
     env:
       SSH_USERNAME: ${{ secrets.SSH_USERNAME }}
       SSH_HOST: ${{ secrets.SSH_HOST }}
@@ -87,4 +86,4 @@ jobs:
               git clone -b main https://github.com/${{ github.repository}} . || { echo "Failed to clone repository"; exit 1; }
             fi
 
-            bash ./scripts/deploy_app.sh production https://github.com/${{ github.repository}} SERVER_PORT=${{ env.SERVER_PORT }} DB_NAME=${{ env.DB_NAME }} USERNAME=${{ env.USERNAME }} APP_NAME=${{ env.APP_NAME }} APP_URL=${{ env.APP_URL }}
+            bash ./scripts/deploy_app.sh production https://github.com/${{ github.repository}} SERVER_PORT=${{ env.SERVER_PORT }} DB_NAME=${{ env.DB_NAME }} USERNAME=${{ env.USERNAME }} APP_NAME=${{ env.APP_NAME }} APP_URL=${{ env.APP_URL }} MIGTRATE=true

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -86,4 +86,4 @@ jobs:
               git clone -b main https://github.com/${{ github.repository}} . || { echo "Failed to clone repository"; exit 1; }
             fi
 
-            bash ./scripts/deploy_app.sh production https://github.com/${{ github.repository}} SERVER_PORT=${{ env.SERVER_PORT }} DB_NAME=${{ env.DB_NAME }} USERNAME=${{ env.USERNAME }} APP_NAME=${{ env.APP_NAME }} APP_URL=${{ env.APP_URL }} MIGTRATE=true
+            bash ./scripts/deploy_app.sh production https://github.com/${{ github.repository}} SERVER_PORT=${{ env.SERVER_PORT }} DB_NAME=${{ env.DB_NAME }} USERNAME=${{ env.USERNAME }} APP_NAME=${{ env.APP_NAME }} APP_URL=${{ env.APP_URL }} MIGRATE=true

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -52,7 +52,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    needs: test
+    needs: build_and_test
     if: github.event_name == 'push'
     env:
       SSH_USERNAME: ${{ secrets.SSH_USERNAME }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build and test:
     runs-on: ubuntu-latest
+    env:
       TEST_USERNAME: postgres
       TEST_PASSWORD: password
       TEST_DB_NAME: db_name
@@ -48,7 +49,7 @@ jobs:
         run: curl http://localhost:8019
       - name: Run All Tests
         run: go test ./... -timeout 99999s
-  
+
   deploy:
     runs-on: ubuntu-latest
     needs: test

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -9,22 +9,8 @@ on:
       - staging
 
 jobs:
-  build:
+  build and test:
     runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-      - name: Set Golang
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.22.1"
-      - name: Build the application
-        run: go build -o staging_app
-
-  test:
-    runs-on: ubuntu-latest
-    needs: build
-    env:
       TEST_USERNAME: postgres
       TEST_PASSWORD: password
       TEST_DB_NAME: db_name
@@ -46,14 +32,27 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+      - name: Set Golang
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.22.1"
       - name: Create app config file
         run: cp app-sample.env app.env
+      - name: Build the application
+        run: go build -o staging_app
+      - name: Run the application
+        run: nohup ./staging_app > /dev/null 2>&1 &
+      - name: Wait for application to start
+        run: sleep 30s
+      - name: Test for reachability
+        run: curl http://localhost:8019
       - name: Run All Tests
         run: go test ./... -timeout 99999s
-
+  
   deploy:
     runs-on: ubuntu-latest
     needs: test
+    if: github.event_name == 'push'
     env:
       SSH_USERNAME: ${{ secrets.SSH_USERNAME }}
       SSH_HOST: ${{ secrets.SSH_HOST }}
@@ -87,4 +86,4 @@ jobs:
               git clone -b staging https://github.com/${{ github.repository}} . || { echo "Failed to clone repository"; exit 1; }
             fi
 
-            bash ./scripts/deploy_app.sh staging https://github.com/${{ github.repository}} SERVER_PORT=${{ env.SERVER_PORT }} DB_NAME=${{ env.DB_NAME }} USERNAME=${{ env.USERNAME }} APP_NAME=${{ env.APP_NAME }} APP_URL=${{ env.APP_URL }}
+            bash ./scripts/deploy_app.sh staging https://github.com/${{ github.repository}} SERVER_PORT=${{ env.SERVER_PORT }} DB_NAME=${{ env.DB_NAME }} USERNAME=${{ env.USERNAME }} APP_NAME=${{ env.APP_NAME }} APP_URL=${{ env.APP_URL }} MIGTRATE=true

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -86,4 +86,4 @@ jobs:
               git clone -b staging https://github.com/${{ github.repository}} . || { echo "Failed to clone repository"; exit 1; }
             fi
 
-            bash ./scripts/deploy_app.sh staging https://github.com/${{ github.repository}} SERVER_PORT=${{ env.SERVER_PORT }} DB_NAME=${{ env.DB_NAME }} USERNAME=${{ env.USERNAME }} APP_NAME=${{ env.APP_NAME }} APP_URL=${{ env.APP_URL }} MIGTRATE=true
+            bash ./scripts/deploy_app.sh staging https://github.com/${{ github.repository}} SERVER_PORT=${{ env.SERVER_PORT }} DB_NAME=${{ env.DB_NAME }} USERNAME=${{ env.USERNAME }} APP_NAME=${{ env.APP_NAME }} APP_URL=${{ env.APP_URL }} MIGRATE=true

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -9,7 +9,7 @@ on:
       - staging
 
 jobs:
-  build and test:
+  build_and_test:
     runs-on: ubuntu-latest
     env:
       TEST_USERNAME: postgres

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -52,7 +52,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    needs: test
+    needs: build_and_test
     if: github.event_name == 'push'
     env:
       SSH_USERNAME: ${{ secrets.SSH_USERNAME }}

--- a/app-sample.env
+++ b/app-sample.env
@@ -19,7 +19,7 @@ SSLMODE=disable
 USERNAME=postgres
 PASSWORD=password
 DB_NAME=db_name
-MIGRATE=true
+MIGRATE=false
 
 # Test #
 TEST_DB_HOST=localhost


### PR DESCRIPTION
This PR does the following:
1. Updates the workflows to build and test simultaneously
2. Use the migrate=true in the workflow deploy step
3. Change the app-sample.env back to false