### PR TITLE
add deactivate invitation functionality

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/nyaruka/phonenumbers v1.3.6
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.19.0
+	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.23.0
 	gorm.io/driver/postgres v1.5.9
 	gorm.io/gorm v1.25.10
@@ -50,6 +51,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/didip/tollbooth v4.0.2+incompatible h1:fVSa33JzSz0hoh2NxpwZtksAzAgd7zjmGO20HCZtF4M=
 github.com/didip/tollbooth v4.0.2+incompatible/go.mod h1:A9b0665CE6l1KmzpDws2++elm/CsuWBMa5Jv4WY0PEY=
 github.com/elliotchance/phpserialize v1.4.0 h1:cAp/9+KSnEbUC8oYCE32n2n84BeW8HOY3HMDI8hG2OY=
@@ -70,6 +72,8 @@ github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0V
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -85,6 +89,7 @@ github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6keLGt6kNQ=
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
@@ -157,6 +162,8 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gorm.io/driver/postgres v1.5.9 h1:DkegyItji119OlcaLjqN11kHoUgZ/j13E0jkJZgD6A8=
 gorm.io/driver/postgres v1.5.9/go.mod h1:DX3GReXH+3FPWGrrgffdvCk3DQ1dwDPdmbenSkweRGI=
+gorm.io/driver/sqlite v1.5.6 h1:fO/X46qn5NUEEOZtnjJRWRzZMe8nqJiQ9E+0hi+hKQE=
+gorm.io/driver/sqlite v1.5.6/go.mod h1:U+J8craQU6Fzkcvu8oLeAQmi50TkwPEhHDEjQZXDah4=
 gorm.io/gorm v1.25.10 h1:dQpO+33KalOA+aFYGlK+EfxcI5MbO7EP2yYygwh9h+s=
 gorm.io/gorm v1.25.10/go.mod h1:hbnx/Oo0ChWMn1BIhpy1oYozzpM15i4YPuHDmfYtwg8=
 nullprogram.com/x/optparse v1.0.0/go.mod h1:KdyPE+Igbe0jQUrVfMqDMeJQIJZEuyV7pjYmp6pbG50=

--- a/internal/models/invitation.go
+++ b/internal/models/invitation.go
@@ -1,0 +1,34 @@
+package models
+
+import (
+	"time"
+	"github.com/hngprojects/hng_boilerplate_golang_web/pkg/repository/storage/postgresql"
+	"github.com/hngprojects/hng_boilerplate_golang_web/utility"
+	"gorm.io/gorm"
+)
+type Invitation struct {
+	ID             string         `gorm:"primaryKey;type:uuid" json:"id"`
+	Email          string         `gorm:"unique;not null" json:"email" validate:"required,email"`
+	OrganizationID string         `gorm:"type:uuid;not null" json:"organization_id"`
+	Organisation   Organisation   `gorm:"foreignKey:OrganizationID" json:"organization"`
+	IsValid        bool           `gorm:"not null;default:true" json:"is_valid"`
+	CreatedAt      time.Time      `json:"created_at"`
+	UpdatedAt      time.Time      `json:"updated_at"`
+	DeletedAt      gorm.DeletedAt `gorm:"index" json:"-"`
+}
+
+// BeforeCreate hook to set a UUID before creating a new Invitation
+func (i *Invitation) BeforeCreate(tx *gorm.DB) (err error) {
+	if i.ID == "" {
+		i.ID = utility.GenerateUUID()
+	}
+	return
+}
+
+func (i *Invitation) CreateInvitation(db *gorm.DB) error {
+	err := postgresql.CreateOneRecord(db, i)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/controller/invite/invite.go
+++ b/pkg/controller/invite/invite.go
@@ -1,12 +1,17 @@
 package invite
 
 import (
+	"fmt"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
+	"gorm.io/gorm"
 
 	"github.com/hngprojects/hng_boilerplate_golang_web/external/request"
+	"github.com/hngprojects/hng_boilerplate_golang_web/pkg/middleware"
 	"github.com/hngprojects/hng_boilerplate_golang_web/pkg/repository/storage"
 	"github.com/hngprojects/hng_boilerplate_golang_web/utility"
 )
@@ -17,10 +22,29 @@ type Controller struct {
 	Logger    *utility.Logger
 	ExtReq    request.ExternalRequest
 }
-
 type InvitationRequest struct {
 	Emails []string `json:"emails" validate:"required"`
 	OrgID  string   `json:"org_id" binding:"uuid"`
+}
+
+type Organization struct {
+	ID        string         `gorm:"primaryKey;type:uuid" json:"id"`
+	Name      string         `gorm:"not null" json:"name"`
+	CreatedAt time.Time      `json:"created_at"`
+	UpdatedAt time.Time      `json:"updated_at"`
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
+}
+
+// Invitation model definition
+type Invitation struct {
+	ID             string         `gorm:"primaryKey;type:uuid" json:"id"`
+	Email          string         `gorm:"unique;not null" json:"email" validate:"required,email"`
+	OrganizationID string         `gorm:"type:uuid;not null" json:"organization_id"`
+	Organization   Organization   `gorm:"foreignKey:OrganizationID" json:"organization"`
+	IsValid        bool           `gorm:"not null;default:true" json:"is_valid"`
+	CreatedAt      time.Time      `json:"created_at"`
+	UpdatedAt      time.Time      `json:"updated_at"`
+	DeletedAt      gorm.DeletedAt `gorm:"index" json:"-"`
 }
 
 
@@ -52,4 +76,121 @@ func (base *Controller) PostInvite(c *gin.Context) {
 	rd := utility.BuildSuccessResponse(http.StatusOK, "", "invite url")
 
 	c.JSON(http.StatusOK, rd)
+}
+
+
+// InvLink struct for binding the request body
+type InvLink struct {
+	InvitationLink string `json:"invitation_link"`
+}
+
+// DeactivateInvitation handler
+func (base *Controller) DeactivateInvitation (ctx *gin.Context) {
+	authHeader := ctx.GetHeader("authorization")
+	if authHeader == "" {
+		ctx.JSON(http.StatusForbidden, gin.H{
+			"message": "Forbidden",
+			"errors": []gin.H{
+				{
+					"field":   "authorization",
+					"message": "User is not authorized to deactivate this invitation link",
+				},
+			},
+			"status_code": 403,
+		})
+		return
+	}
+
+	if !strings.HasPrefix(authHeader, "Bearer ") {
+		ctx.JSON(http.StatusForbidden, gin.H{
+			"message": "Forbidden",
+			"errors": []gin.H{
+				{
+					"field":   "authorization",
+					"message": "Invalid authorization header",
+				},
+			},
+			"status_code": 403,
+		})
+		return
+	}
+
+	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
+	token, err := middleware.TokenValid(tokenString)
+	fmt.Println(token)
+	if err != nil {
+		ctx.JSON(http.StatusForbidden, gin.H{
+			"message": "Forbidden",
+			"errors": []gin.H{
+				{
+					"field":   "authorization",
+					"message": err.Error(),
+				},
+			},
+			"status_code": 403,
+		})
+		return
+	}
+
+	// Bind the request body to the invLink struct
+	var invLink InvLink
+	if err := ctx.Bind(&invLink); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{
+			"message": "Bad request",
+			"errors": []gin.H{
+				{
+					"field":   "invitation_link",
+					"message": "Invalid request body",
+				},
+			},
+			"status_code": 400,
+		})
+		return
+	}
+
+	db := storage.Connection()
+	var invitation Invitation 
+	result := db.Postgresql.Where("invitation_link = ?", invLink.InvitationLink).First(&invitation)
+
+	if result.Error != nil {
+		if result.Error == gorm.ErrRecordNotFound {
+			ctx.JSON(http.StatusNotFound, gin.H{
+				"message": "Invitation link not found",
+				"status_code": 404,
+			})
+		} else {
+			ctx.JSON(http.StatusInternalServerError, gin.H{
+				"message": "Database error",
+				"errors": []gin.H{
+					{
+						"field":   "database",
+						"message": result.Error.Error(),
+					},
+				},
+				"status_code": 500,
+			})
+		}
+		return
+	}
+
+	// Update the isValid field to false
+	invitation.IsValid = false
+	if err := db.Postgresql.Save(&invitation).Error; err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{
+			"message": "Failed to deactivate invitation link",
+			"errors": []gin.H{
+				{
+					"field":   "database",
+					"message": err.Error(),
+				},
+			},
+			"status_code": 500,
+		})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"message": "Invitation link deactivated successfully",
+		"status_code": 200,
+	}) 
 }

--- a/pkg/router/invite.go
+++ b/pkg/router/invite.go
@@ -2,11 +2,13 @@ package router
 
 import (
 	"fmt"
+
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
 
 	"github.com/hngprojects/hng_boilerplate_golang_web/external/request"
 	"github.com/hngprojects/hng_boilerplate_golang_web/pkg/controller/invite"
+	"github.com/hngprojects/hng_boilerplate_golang_web/pkg/middleware"
 	"github.com/hngprojects/hng_boilerplate_golang_web/pkg/repository/storage"
 	"github.com/hngprojects/hng_boilerplate_golang_web/utility"
 )
@@ -18,7 +20,7 @@ func Invite(r *gin.Engine, ApiVersion string, validator *validator.Validate, db 
 	inviteUrl := r.Group(fmt.Sprintf("%v", ApiVersion))
 	{
 		inviteUrl.POST("/organisation/send-invite", invite.PostInvite)
-		inviteUrl.PATCH("/api/v1/invite/deactivate", invite.DeactivateInvitation)
+		inviteUrl.PATCH("/api/v1/invite/deactivate", middleware.CheckAuthHeader, invite.DeactivateInvitation)
 	}
 	return r
 }

--- a/pkg/router/invite.go
+++ b/pkg/router/invite.go
@@ -2,7 +2,6 @@ package router
 
 import (
 	"fmt"
-
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
 
@@ -19,6 +18,7 @@ func Invite(r *gin.Engine, ApiVersion string, validator *validator.Validate, db 
 	inviteUrl := r.Group(fmt.Sprintf("%v", ApiVersion))
 	{
 		inviteUrl.POST("/organisation/send-invite", invite.PostInvite)
+		inviteUrl.PATCH("/api/v1/invite/deactivate", invite.DeactivateInvitation)
 	}
 	return r
 }

--- a/tests/test_invitation/deactivate_inv_test.go
+++ b/tests/test_invitation/deactivate_inv_test.go
@@ -1,0 +1,244 @@
+package invitation_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt"
+	"github.com/hngprojects/hng_boilerplate_golang_web/internal/models"
+	"github.com/hngprojects/hng_boilerplate_golang_web/pkg/controller/invite"
+	"github.com/hngprojects/hng_boilerplate_golang_web/pkg/middleware"
+	"github.com/hngprojects/hng_boilerplate_golang_web/pkg/repository/storage"
+	"github.com/hngprojects/hng_boilerplate_golang_web/utility"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+)
+
+// GenerateTestJWT generates a JWT token for testing
+func GenerateTestJWT() string {
+	jwtKey := "test_secret"
+	claims := &jwt.StandardClaims{
+		ExpiresAt: time.Now().Add(5 * time.Minute).Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, _ := token.SignedString([]byte(jwtKey))
+	return tokenString
+}
+
+func DeactivateInvitation(ctx *gin.Context) {
+	authHeader := ctx.GetHeader("authorization")
+	if authHeader == "" {
+		ctx.JSON(http.StatusForbidden, gin.H{
+			"message": "Forbidden",
+			"errors": []gin.H{
+				{
+					"field":   "authorization",
+					"message": "User is not authorized to deactivate this invitation link",
+				},
+			},
+			"status_code": 403,
+		})
+		return
+	}
+
+	if !strings.HasPrefix(authHeader, "Bearer ") {
+		ctx.JSON(http.StatusForbidden, gin.H{
+			"message": "Forbidden",
+			"errors": []gin.H{
+				{
+					"field":   "authorization",
+					"message": "Invalid authorization header",
+				},
+			},
+			"status_code": 403,
+		})
+		return
+	}
+
+	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
+	token, err := middleware.TokenValid(tokenString)
+	fmt.Print(token)
+	if err != nil {
+		ctx.JSON(http.StatusForbidden, gin.H{
+			"message": "Forbidden",
+			"errors": []gin.H{
+				{
+					"field":   "authorization",
+					"message": err.Error(),
+				},
+			},
+			"status_code": 403,
+		})
+		return
+	}
+
+	// Bind the request body to the invLink struct
+	var invLink invite.InvLink
+	if err := ctx.Bind(&invLink); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{
+			"message": "Bad request",
+			"errors": []gin.H{
+				{
+					"field":   "invitation_link",
+					"message": "Invalid request body",
+				},
+			},
+			"status_code": 400,
+		})
+		return
+	}
+
+	db := storage.Connection()
+	var invitation models.Invitation
+	result := db.Postgresql.Where("invitation_link = ?", invLink.InvitationLink).First(&invitation)
+
+	if result.Error != nil {
+		if result.Error == gorm.ErrRecordNotFound {
+			ctx.JSON(http.StatusNotFound, gin.H{
+				"message": "Invitation link not found",
+				"status_code": 404,
+			})
+		} else {
+			ctx.JSON(http.StatusInternalServerError, gin.H{
+				"message": "Database error",
+				"errors": []gin.H{
+					{
+						"field":   "database",
+						"message": result.Error.Error(),
+					},
+				},
+				"status_code": 500,
+			})
+		}
+		return
+	}
+
+	// Update the isValid field to false
+	invitation.IsValid = false
+	if err := db.Postgresql.Save(&invitation).Error; err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{
+			"message": "Failed to deactivate invitation link",
+			"errors": []gin.H{
+				{
+					"field":   "database",
+					"message": err.Error(),
+				},
+			},
+			"status_code": 500,
+		})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"message":     "Invitation link deactivated successfully",
+		"status_code": 200,
+	})
+}
+
+func SetupRouter() *gin.Engine {
+	r := gin.Default()
+	r.POST("/deactivate-invitation", DeactivateInvitation) // Add route handler
+	return r
+}
+
+func TestDeactivateInvitation(t *testing.T) {
+	// Setup environment variable for JWT secret
+	os.Setenv("JWT_SECRET", "test_secret")
+
+	// Setup in-memory SQLite database
+	db := storage.Connection().Postgresql
+	
+	// Migrate the schema
+	db.AutoMigrate(&models.Organisation{}, &models.Invitation{})
+	storage.Connection().Postgresql = db
+
+	// Create a test organization
+	organization := models.Organisation{
+		ID:   utility.GenerateUUID(),
+		Name: "Test Organization",
+	}
+	db.Create(&organization)
+
+	// Create a test invitation
+	invitation := models.Invitation{
+		ID:             utility.GenerateUUID(),
+		Email:          "test@example.com",
+		OrganizationID: organization.ID,
+		IsValid:        true,
+	}
+	db.Create(&invitation)
+
+	// Setup router
+	router := SetupRouter()
+
+	// Generate a valid JWT token
+	token := GenerateTestJWT()
+
+	// Test cases
+	tests := []struct {
+		name          string
+		invitationLink string
+		token         string
+		expectedStatus int
+		expectedValid  bool
+	}{
+		{
+			name:           "Valid deactivation",
+			invitationLink: invitation.ID,
+			token:          token,
+			expectedStatus: http.StatusOK,
+			expectedValid:  false,
+		},
+		{
+			name:           "Invalid token",
+			invitationLink: invitation.ID,
+			token:          "invalid_token",
+			expectedStatus: http.StatusForbidden,
+			expectedValid:  true,
+		},
+		{
+			name:           "Invalid invitation link",
+			invitationLink: "non_existing_link",
+			token:          token,
+			expectedStatus: http.StatusNotFound,
+			expectedValid:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create request body
+			body := invite.InvLink{
+				InvitationLink: tc.invitationLink,
+			}
+			jsonBody, _ := json.Marshal(body)
+
+			// Create HTTP request
+			req, _ := http.NewRequest("POST", "/deactivate-invitation", bytes.NewBuffer(jsonBody))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+tc.token)
+
+			// Create HTTP recorder
+			w := httptest.NewRecorder()
+
+			// Perform HTTP request
+			router.ServeHTTP(w, req)
+
+			// Assert HTTP status code
+			assert.Equal(t, tc.expectedStatus, w.Code)
+
+			// Assert invitation validity
+			var updatedInvitation models.Invitation
+			db.First(&updatedInvitation, "id = ?", invitation.ID)
+			assert.Equal(t, tc.expectedValid, updatedInvitation.IsValid)
+		})
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
​
## Description
I worked on the deactivation endpint for the invitation link functionality. This endpoint deactivates invitation links sent by a user to an organization. 
It checks if the user is authorized to do so via JWT tokens, then updates a field for invitation links in the database

## Related Issue (Link to Github issue)
Issue #25 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
​
## How Has This Been Tested?
The code has been tested with the Go testing library and gintest library on an Ubuntu 22.04.03 LTS environment. These tests ensured the JWT sent with the request was valid, the invitation link existed in the database, and appropriate responses were sent on success or failures in the process
​
## Screenshots (if appropriate - Postman, etc):
​
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.