### PR TITLE
feat: get users region data

### DIFF
--- a/pkg/controller/user/regions.go
+++ b/pkg/controller/user/regions.go
@@ -43,3 +43,20 @@ func (base *Controller) UpdateUserRegion(c *gin.Context) {
 	c.JSON(http.StatusOK, rd)
 
 }
+
+func (base *Controller) GetUserRegion(c *gin.Context) {
+	var (
+		userID = c.Param("user_id")
+	)
+
+	respData, code, err := service.GetUserRegion(userID, base.Db.Postgresql, c)
+	if err != nil {
+		rd := utility.BuildErrorResponse(code, "error", err.Error(), err, nil)
+		c.JSON(code, rd)
+		return
+	}
+
+	rd := utility.BuildSuccessResponse(http.StatusOK, "User region retrieved successfully", respData)
+	c.JSON(http.StatusOK, rd)
+
+}

--- a/pkg/router/user.go
+++ b/pkg/router/user.go
@@ -27,6 +27,7 @@ func User(r *gin.Engine, ApiVersion string, validator *validator.Validate, db *s
 		userUrl.GET("/users/:user_id/organisations", user.GetAUserOrganisation)
 		userUrl.PUT("/users/:user_id/roles/:role_id", user.AssignRoleToUser)
 		userUrl.PUT("/users/:user_id/regions", user.UpdateUserRegion)
+		userUrl.GET("/users/:user_id/regions", user.GetUserRegion)
 	}
 	adminUrl.GET("/users", user.GetAllUsers)
 

--- a/tests/test_users/base.go
+++ b/tests/test_users/base.go
@@ -54,4 +54,7 @@ func SetupUsersRoutes(r *gin.Engine, userController *user.Controller) {
 	r.PUT("/api/v1/users/:user_id/regions",
 		middleware.Authorize(userController.Db.Postgresql, models.RoleIdentity.SuperAdmin),
 		userController.UpdateUserRegion)
+	r.GET("/api/v1/users/:user_id/regions",
+		middleware.Authorize(userController.Db.Postgresql, models.RoleIdentity.SuperAdmin, models.RoleIdentity.User),
+		userController.GetUserRegion)
 }

--- a/tests/test_users/get_user_region_test.go
+++ b/tests/test_users/get_user_region_test.go
@@ -13,13 +13,13 @@ import (
 	"github.com/hngprojects/hng_boilerplate_golang_web/utility"
 )
 
-func TestGetAllUsers(t *testing.T) {
+func TestGetUserRegion(t *testing.T) {
+
 	_, userController := SetupUsersTestRouter()
 	db := userController.Db.Postgresql
 	currUUID := utility.GenerateUUID()
 	password, _ := utility.HashPassword("password")
 
-	// Creating test users
 	adminUser := models.User{
 		ID:       utility.GenerateUUID(),
 		Name:     "Admin User",
@@ -35,8 +35,17 @@ func TestGetAllUsers(t *testing.T) {
 		Role:     int(models.RoleIdentity.User),
 	}
 
+	region := models.UserRegionTimezoneLanguage{
+		ID:         utility.GenerateUUID(),
+		UserID:     regularUser.ID,
+		RegionID:   utility.GenerateUUID(),
+		TimezoneID: utility.GenerateUUID(),
+		LanguageID: utility.GenerateUUID(),
+	}
+
 	db.Create(&adminUser)
 	db.Create(&regularUser)
+	db.Create(&region)
 
 	setup := func() (*gin.Engine, *auth.Controller) {
 		router, userController := SetupUsersTestRouter()
@@ -49,16 +58,15 @@ func TestGetAllUsers(t *testing.T) {
 		return router, &authController
 	}
 
-	t.Run("Successful Get All Users", func(t *testing.T) {
+	t.Run("Successful Get User Region for admin", func(t *testing.T) {
 		router, authController := setup()
-
 		loginData := models.LoginRequestModel{
 			Email:    adminUser.Email,
 			Password: "password",
 		}
 		token := tests.GetLoginToken(t, router, *authController, loginData)
 
-		req, _ := http.NewRequest(http.MethodGet, "/api/v1/users", nil)
+		req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/users/%s/regions", regularUser.ID), nil)
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
@@ -67,42 +75,63 @@ func TestGetAllUsers(t *testing.T) {
 
 		tests.AssertStatusCode(t, resp.Code, http.StatusOK)
 		response := tests.ParseResponse(resp)
-		tests.AssertResponseMessage(t, response["message"].(string), "Users retrieved successfully")
+		tests.AssertResponseMessage(t, response["status"].(string), "success")
+		tests.AssertResponseMessage(t, response["message"].(string), "User region retrieved successfully")
+
 	})
 
-	t.Run("Unauthorized Access", func(t *testing.T) {
-		router, _ := setup()
-
-		req, _ := http.NewRequest(http.MethodGet, "/api/v1/users", nil)
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", "Bearer invalid_token")
-
-		resp := httptest.NewRecorder()
-		router.ServeHTTP(resp, req)
-
-		tests.AssertStatusCode(t, resp.Code, http.StatusUnauthorized)
-		response := tests.ParseResponse(resp)
-		tests.AssertResponseMessage(t, response["message"].(string), "Token is invalid!")
-	})
-
-	t.Run("Forbidden Access - Regular User Trying to Get All users", func(t *testing.T) {
+	t.Run("Successful Get User Region for regular user", func(t *testing.T) {
 		router, authController := setup()
-
 		loginData := models.LoginRequestModel{
 			Email:    regularUser.Email,
 			Password: "password",
 		}
 		token := tests.GetLoginToken(t, router, *authController, loginData)
 
-		req, _ := http.NewRequest(http.MethodGet, "/api/v1/users", nil)
+		req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/users/%s/regions", regularUser.ID), nil)
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
 		resp := httptest.NewRecorder()
 		router.ServeHTTP(resp, req)
 
+		tests.AssertStatusCode(t, resp.Code, http.StatusOK)
+		response := tests.ParseResponse(resp)
+		tests.AssertResponseMessage(t, response["message"].(string), "User region retrieved successfully")
+	})
+
+	t.Run("Unauthorized", func(t *testing.T) {
+		router, _ := setup()
+
+		req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/users/%s/regions", regularUser.ID), nil)
+		req.Header.Set("Content-Type", "application/json")
+
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+
 		tests.AssertStatusCode(t, resp.Code, http.StatusUnauthorized)
 		response := tests.ParseResponse(resp)
-		tests.AssertResponseMessage(t, response["message"].(string), "role not authorized!")
+		tests.AssertResponseMessage(t, response["message"].(string), "Token could not be found!")
+	})
+
+	t.Run("User ID not found", func(t *testing.T) {
+		router, authController := setup()
+		loginData := models.LoginRequestModel{
+			Email:    adminUser.Email,
+			Password: "password",
+		}
+		token := tests.GetLoginToken(t, router, *authController, loginData)
+
+		req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/users/%s/regions", utility.GenerateUUID()), nil)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+
+		tests.AssertStatusCode(t, resp.Code, http.StatusNotFound)
+		response := tests.ParseResponse(resp)
+		tests.AssertResponseMessage(t, response["status"].(string), "error")
+		tests.AssertResponseMessage(t, response["message"].(string), "user not found")
 	})
 }


### PR DESCRIPTION
## Description

This pull request introduces a new API endpoint to retrieve the region information associated with a specific user.

### Key Features

* **Endpoint**: `GET /api/v1/users/{user_id}/regions`
* **Functionality**: Retrieves the region details for the specified user.
* **Authentication**: Requires a valid JWT token for access.
* **Authorization**: Only authenticated users with appropriate permissions can access the data.

### Acceptance Criteria

* The endpoint should accept HTTP GET requests.
* The request must include a valid authentication token in the Authorization header.
* The response should return the region details associated with the specified user.

**Authorization Header**:
```json
{
    "Authorization": "Bearer <token>"
}
```

### Related Issue

This pull request addresses [Issue 233](https://github.com/hngprojects/hng_boilerplate_golang_web/issues/233).

### How Has This Been Tested?

The changes have been tested with the following methods:

* **Integration Tests**:
  * Verified successful retrieval of user region information.
  * Tested unauthorized access attempts.
  * Handled cases where the user ID is invalid or not found.

### Screenshots (if appropriate - Postman, etc.)
![image](https://github.com/user-attachments/assets/99ec21f2-e2b2-43bd-8a81-35f07501a83a)
![image](https://github.com/user-attachments/assets/09d62371-7f80-4924-b2e8-e3944328ce7a)
![image](https://github.com/user-attachments/assets/f980ddf8-a04a-4569-9faa-4af26afb7f6f)


### Types of Changes

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

* [x] My code follows the code style of this project.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.

--