### PR TITLE
bugfix: add new line to .env creation step

### DIFF
--- a/scripts/deploy_app.sh
+++ b/scripts/deploy_app.sh
@@ -63,7 +63,7 @@ do
         sed -i "s|^$KEY=.*|$KEY=$VALUE|" app.env
     else
         # Add the new key-value pair
-        echo "$KEY=$VALUE" >> app.env
+        echo -e "\n$KEY=$VALUE" >> app.env
     fi
 done
 


### PR DESCRIPTION
This new line addition ensures that environment variables not defined in the app-sample.env get preppended with new lines before they are added

<!--- Provide a general summary of your changes in the Title above -->
​
## Description
<!--- Describe your changes in detail -->
1. I ensured that I prepend a new line before each new field that is to be added to the .env file in the deploy_app script
​
## Related Issue (Link to Github issue)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
​
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
​
## Screenshots (if appropriate - Postman, etc):
​
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.