### PR TITLE
fix: 404 err handling for fetch all help center topics

### DIFF
--- a/pkg/controller/helpcenter/helpcenter.go
+++ b/pkg/controller/helpcenter/helpcenter.go
@@ -76,10 +76,10 @@ func (base *Controller) FetchAllTopics(c *gin.Context) {
 	topics, paginationResponse, err := service.GetPaginatedTopics(c, base.Db.Postgresql)
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
-			rd := utility.BuildErrorResponse(http.StatusNotFound, "error", "No Job post not found", err, nil)
+			rd := utility.BuildErrorResponse(http.StatusNotFound, "error", "Topics not found", err, nil)
 			c.JSON(http.StatusNotFound, rd)
 		} else {
-			rd := utility.BuildErrorResponse(http.StatusInternalServerError, "error", "Failed to fetch job post", err, nil)
+			rd := utility.BuildErrorResponse(http.StatusInternalServerError, "error", "Failed to fetch topics", err, nil)
 			c.JSON(http.StatusInternalServerError, rd)
 		}
 		return

--- a/services/helpcenter/helpcenter.go
+++ b/services/helpcenter/helpcenter.go
@@ -40,6 +40,11 @@ func GetPaginatedTopics(c *gin.Context, db *gorm.DB) ([]HelpCntSummary, postgres
 	if err != nil {
 		return nil, paginationResponse, err
 	}
+
+	if len(helpCnts) == 0 {
+		return nil, paginationResponse, gorm.ErrRecordNotFound
+	}
+	
 	var topicSummaries []HelpCntSummary
 	for _, Hlp := range helpCnts {
 		summary := HelpCntSummary{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
​
## Description
<!--- Describe your changes in detail -->
Fixed the error handling to properly return 404 error when no topic has been created priorly.
​
[API DOC LINK](https://staging.api-golang.boilerplate.hng.tech/api/docs/index.html)
## Related Issue (Link to Github issue)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[#270](https://github.com/hngprojects/hng_boilerplate_golang_web/issues/270)
​
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Yes, the test case ensures it return proper error of 404, when there is no help center topics from the DB, while maintain the main functionality of fetch all help center topics if it is present on the DB.
​
## Screenshots (if appropriate - Postman, etc):
![Screenshot (356)](https://github.com/user-attachments/assets/7e85d904-cd7d-4daf-896b-abb833fb2a68)

WHEN NO TOPICS IS PRESENT:
![Screenshot (355)](https://github.com/user-attachments/assets/b635ed25-726b-41ed-bf15-850fbc700e84)

WHEN THERE IS A TOPIC
![Screenshot (354)](https://github.com/user-attachments/assets/81ad197c-a6bd-444d-9f5d-713ae654b82d)
​
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
